### PR TITLE
change(integraciones): remove `esjs` from name/url

### DIFF
--- a/src/.vitepress/config.ts
+++ b/src/.vitepress/config.ts
@@ -103,8 +103,8 @@ export default async () => {
       items: [
         {
           items: [
+            { text: 'EsJS + Express', link: '/integraciones/express' },
             { text: 'Hono + Knex + MySQL', link: '/integraciones/hono-knex-mysql' },
-            { text: 'EsJS + Express', link: '/integraciones/express-esjs' }
           ],
         },
       ],

--- a/src/integraciones/express.md
+++ b/src/integraciones/express.md
@@ -30,7 +30,7 @@
     ```
 
     - `src/app.esjs`: Archivo principal de la aplicación.
-    - `src/otro-archivo.esjs`: Módulo esjs.
+    - `src/otro-archivo.esjs`: Módulo EsJS.
     - `vite.config.js`: Archivo de configuración de Vite.
 
 2. Instalar dependencias:

--- a/src/primeros-pasos.md
+++ b/src/primeros-pasos.md
@@ -364,8 +364,8 @@ La instalación manual puede realizarse utilizando [Babel](https://babeljs.io/) 
 
 Te recomendamos algunas integraciones para que puedas continuar aprendiendo sobre EsJS:
 
-- [Instalación EsJS + Express](./integraciones/express-esjs.md)
-- [Instalación Hono + Knex + MySql](./integraciones/hono-knex-mysql.md)
+- [Instalación EsJS + Express](./integraciones/express.md)
+- [Instalación EsJS + Hono + Knex + MySql](./integraciones/hono-knex-mysql.md)
 
 ## Tutorial Interactivo
 


### PR DESCRIPTION
Para mantener el estándar, las guías de integraciones no deberían contener `esjs` en el nombre (y por lo tanto la URL). De manera que quede:

- es.js.org/integraciones/express
- es.js.org/integraciones/hono-knex-mysql

y **no**:

- es.js.org/integraciones/express`-esjs`
- es.js.org/integraciones/`esjs-`hono-knex-mysql

(ya que `esjs` se vuelve a repetir en la URL)