### PR TITLE
docs(express): usar puerto especificado por vite

### DIFF
--- a/src/integraciones/express.md
+++ b/src/integraciones/express.md
@@ -118,13 +118,14 @@
   importar httpDevServer desde 'vavite/http-dev-server'
 
   const servidor = express()
-  const puerto = process.env.PORT || 4500
+  mut puerto = process.env.PORT || 4500
 
   servidor.use('/', (req, res) => {
     res.send('¡Hola, mundo hispano hablante!')
   })
 
   si (httpDevServer) {
+    puerto = httpDevServer.address().port
     httpDevServer.on('request', servidor)
     consola.escribir(`Servidor corriendo en el puerto ${puerto}`)
   }


### PR DESCRIPTION
# Pull Request - Actualización de Documentación EsJS + Express

## Descripción del PR
Se han realizado actualizaciones en el archivo de documentación de EsJS + Express con el objetivo de mejorar la claridad la integración con el puerto que VITE proporciona y el puerto que se usará en producción. A continuación, se describen los cambios realizados:

### Cambios principales:
1. **Modificación del archivo `src/integraciones/express.md`**:
   - Se cambio `const puerto = process.env.PORT || 4500` por `mut puerto = process.env.PORT || 4500`.
   - Si el proyecto está en modo desarrollo, toma el puerto asignado por VITE en la linea 128 `httpDevServer.address().port`.

### Archivo actualizado:
   - express.md

### Motivación:
El cambio fue solicitado por el autor en el canal de Discord dónde se discuten temas relacionados a EsJs.

Gracias por su tiempo y dedicación para revisar estos cambios. Cualquier comentario o sugerencia será bienvenido.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nuevas Funciones**
	- Se ha añadido una guía para configurar un proyecto de Node.js utilizando EsJS y Express, incluyendo la inicialización del proyecto, estructura de carpetas y configuración del servidor.
- **Documentación**
	- Se han detallado los pasos para la instalación de dependencias y la ejecución del servidor de desarrollo.
	- Se han incluido modificaciones en el archivo `package.json` para nuevos scripts de construcción.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->